### PR TITLE
Added autostatus rules for self

### DIFF
--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -9,21 +9,21 @@ class AutostatusRuleCondition < ActiveRecord::Base
 
   def valid(issue)
   	total_valid_children = Issue.where(
-  		:parent_id => issue.id, 
+  		:parent_id => issue.id,
   		:status_id => autostatus_rule_condition_statuses.pluck(:issue_status_id),
   		:tracker_id => tracker_id,
   		).count
   	status = false
   	case rule_type
-  	 when RULE_TYPE_ONE
+  	when RULE_TYPE_ONE
   	 	status = total_valid_children >= 1
-  	 when RULE_TYPE_ALL
+  	when RULE_TYPE_ALL
      	total_children =  Issue.where(
-  		:parent_id => issue.id, 
+  		:parent_id => issue.id,
   		:tracker_id => tracker_id,
   		).count
   		status = (total_children == total_valid_children && total_children > 0)
-  	 end
-  	 status
+  	end
+  	status
   end
 end

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -8,7 +8,7 @@ class AutostatusRuleCondition < ActiveRecord::Base
   RULE_TYPE_SINGLE = 1;
   RULE_TYPE_ALL = 2;
 
-  def valid?(issue)
+  def valid(issue)
   	@total_valid_children = Issue.where(
   		:parent_id => issue.id,
   		:status_id => autostatus_rule_condition_statuses.pluck(:issue_status_id),
@@ -31,11 +31,11 @@ class AutostatusRuleCondition < ActiveRecord::Base
   end
 
   def single_rules_valid?
-    total_valid_children >= 1
+    @total_valid_children >= 1
   end
 
   def all_rules_valid?
     total_children = Issue.where(:parent_id => issue.id, :tracker_id => tracker_id).count
-    total_children == total_valid_children && total_children > 0
+    total_children == @total_valid_children && total_children > 0
   end
 end

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -55,7 +55,7 @@ class AutostatusRuleCondition < ActiveRecord::Base
     special_field = field[14..-1]
     case special_field
     when 'current_date'
-      Time.now
+      Date.current
     else
       raise Exception.new 'Unknown special field for the Autostatus Rule Condition'
     end

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -16,7 +16,7 @@ class AutostatusRuleCondition < ActiveRecord::Base
   		).count
   	case rule_type
     when RULE_TYPE_SELF
-      self_rules_valid?
+      self_rules_valid_for issue
     when RULE_TYPE_SINGLE
       single_rules_valid?
     when RULE_TYPE_ALL
@@ -26,8 +26,27 @@ class AutostatusRuleCondition < ActiveRecord::Base
 
   private
 
-  def self_rules_valid?
-    false
+  def self_rules_valid_for(issue)
+    case rule_comparator
+    when :gt
+      issue.send(rule_field_first) > issue.send(rule_field_second)
+    when :gte
+      issue.send(rule_field_first) >= issue.send(rule_field_second)
+    when :lt
+      issue.send(rule_field_first) < issue.send(rule_field_second)
+    when :lte
+      issue.send(rule_field_first) <= issue.send(rule_field_second)
+    when :null
+      issue.send(rule_field_first).nil?
+    when :not_null
+      !issue.send(rule_field_first).nil?
+    when :empty
+      issue.send(rule_field_first).empty?
+    when :not_empty
+      !issue.send(rule_field_first).empty?
+    else
+      raise Exception.new 'Unknown rule comparator for the Autostatus Rule Condition'
+    end
   end
 
   def single_rules_valid?

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -4,26 +4,38 @@ class AutostatusRuleCondition < ActiveRecord::Base
   belongs_to :autostatus_rule_definition
   has_many :autostatus_rule_condition_statuses
   has_many :issue_statuses, through: :autostatus_rule_condition_statuses
-  RULE_TYPE_ONE = 1;
+  RULE_TYPE_SELF = 0;
+  RULE_TYPE_SINGLE = 1;
   RULE_TYPE_ALL = 2;
 
-  def valid(issue)
-  	total_valid_children = Issue.where(
+  def valid?(issue)
+  	@total_valid_children = Issue.where(
   		:parent_id => issue.id,
   		:status_id => autostatus_rule_condition_statuses.pluck(:issue_status_id),
   		:tracker_id => tracker_id,
   		).count
-  	status = false
   	case rule_type
-  	when RULE_TYPE_ONE
-  	 	status = total_valid_children >= 1
-  	when RULE_TYPE_ALL
-     	total_children =  Issue.where(
-  		:parent_id => issue.id,
-  		:tracker_id => tracker_id,
-  		).count
-  		status = (total_children == total_valid_children && total_children > 0)
+    when RULE_TYPE_SELF
+      self_rules_valid?
+    when RULE_TYPE_SINGLE
+      single_rules_valid?
+    when RULE_TYPE_ALL
+      all_rules_valid?
   	end
-  	status
+  end
+
+  private
+
+  def self_rules_valid?
+    false
+  end
+
+  def single_rules_valid?
+    total_valid_children >= 1
+  end
+
+  def all_rules_valid?
+    total_children = Issue.where(:parent_id => issue.id, :tracker_id => tracker_id).count
+    total_children == total_valid_children && total_children > 0
   end
 end

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -27,33 +27,17 @@ class AutostatusRuleCondition < ActiveRecord::Base
   private
 
   def condition_valid_for(issue)
+    first_field_value = issue.send rule_field_first
+    result = null_checks_for issue, first_field_value
+    return result unless result == :no_match
+    result = nexus_check_for issue, first_field_value
+    return result unless result == :no_match
     second_field_value = special_field_value_for issue, rule_field_second
-    case rule_comparator
-    when 'in'
-      autostatus_rule_condition_statuses.pluck(:id).contains? issue.send(rule_field_first)
-    when 'gt'
-      issue.send(rule_field_first) > second_field_value
-    when 'gte'
-      issue.send(rule_field_first) >= second_field_value
-    when 'lt'
-      issue.send(rule_field_first) < second_field_value
-    when 'lte'
-      issue.send(rule_field_first) <= second_field_value
-    when 'null'
-      issue.send(rule_field_first).nil?
-    when 'not_null'
-      !issue.send(rule_field_first).nil?
-    when 'empty'
-      issue.send(rule_field_first).empty?
-    when 'not_empty'
-      !issue.send(rule_field_first).empty?
-    else
-      raise Exception.new 'Unknown rule comparator for the Autostatus Rule Condition'
-    end
+    ordering_check_for issue, first_field_value, second_field_value
   end
 
   def special_field_value_for(issue, field)
-    return issue.send(field) unless field ~= /\Aspecial_field_\w+/
+    return issue.send(field) unless field =~ /\Aspecial_field_\w+/
     special_field = field[14..-1]
     case special_field
     when 'current_date'
@@ -63,8 +47,48 @@ class AutostatusRuleCondition < ActiveRecord::Base
     end
   end
 
+  def null_checks_for(issue, value)
+    case rule_comparator
+    when 'null'
+      value.nil?
+    when 'not_null'
+      !value.nil?
+    when 'empty'
+      value.empty?
+    when 'not_empty'
+      !value.empty?
+    else
+    :no_match
+    end
+  end
+
+  def nexus_check_for(issue, value)
+    if rule_comparator == 'in'
+      autostatus_rule_condition_statuses.pluck(:id).contains? issue.send(value)
+    else
+      :no_match
+    end
+  end
+
   def single_rules_valid?
     @total_valid_children >= 1
+  end
+
+  def ordering_check_for(issue, first_value, second_value)
+    return false unless second_value
+    return true unless first_value
+    case rule_comparator
+    when 'gt'
+      first_value > second_value
+    when 'gte'
+      first_value >= second_value
+    when 'lt'
+      first_value < second_value
+    when 'lte'
+      first_value <= second_value
+    else
+      raise Exception.new 'Unknown rule comparator for the Autostatus Rule Condition'
+    end
   end
 
   def all_rules_valid?

--- a/app/models/autostatus_rule_condition.rb
+++ b/app/models/autostatus_rule_condition.rb
@@ -53,8 +53,14 @@ class AutostatusRuleCondition < ActiveRecord::Base
   end
 
   def special_field_value_for(issue, field)
-    return issue.send(field) unless field ~= /special_field\w+/
-    Time.now
+    return issue.send(field) unless field ~= /\Aspecial_field_\w+/
+    special_field = field[14..-1]
+    case special_field
+    when 'current_date'
+      Time.now
+    else
+      raise Exception.new 'Unknown special field for the Autostatus Rule Condition'
+    end
   end
 
   def single_rules_valid?

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -7,16 +7,20 @@ class AutostatusRuleDefinition < ActiveRecord::Base
   attr_accessible :target_status, :priority
 
 
-  def self.find_all_by_tracker_and_current_status_id(tracker_id, current_status_id)
-    rules_by_current_status = AutostatusCurrentStatus.where(:issue_status_id => current_status_id).pluck(:autostatus_rule_definition_id) 
-    if rules_by_current_status.empty? 
+  def self.find_all_for(tracker_id, current_status_id)
+    rules_by_current_status = AutostatusCurrentStatus.where(
+      issue_status_id: current_status_id).pluck(:autostatus_rule_definition_id)
+    if rules_by_current_status.empty?
       return []
     end
-    rules_by_tracker_id = AutostatusTracker.where(:tracker_id => tracker_id).pluck(:autostatus_rule_definition_id)
+    rules_by_tracker_id = AutostatusTracker.where(
+      tracker_id: tracker_id).pluck(:autostatus_rule_definition_id)
     if rules_by_tracker_id.empty?
       return []
     end
-    AutostatusRuleDefinition.where(:id => (rules_by_tracker_id & rules_by_current_status)).order('priority desc').order('id asc')
+    AutostatusRuleDefinition.where(
+      id: (rules_by_tracker_id & rules_by_current_status)
+    ).order('priority desc').order('id asc')
   end
 
 
@@ -24,11 +28,11 @@ class AutostatusRuleDefinition < ActiveRecord::Base
     conditions = autostatus_rule_condition
     issue_rule_status = true
     conditions.each { |condition|
-      issue_rule_status = issue_rule_status && condition.valid(issue)  
+      issue_rule_status = issue_rule_status && condition.valid(issue)
     }
     issue_rule_status
   end
-  
+
   def self.populate
     AutostatusRuleDefinition.destroy_all
     AutostatusTracker.destroy_all
@@ -38,7 +42,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
       {
         :target_status => 'In Progress',
         :tracker => ['Feature'],
-        :current_status => ['Approved', "Ready For Implementation"],
+        :current_status => ['Approved', 'Ready For Implementation'],
         :conditions => [
           {
             :rule_type => AutostatusRuleCondition::RULE_TYPE_ONE,
@@ -47,10 +51,11 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           }
         ]
       },
-# 2. Tracker de tip Feature se va muta in status Ready for Testing cand sunt indeplinite urmatoarele conditii:
-# feature-ul se afla in statusul In Progress
-# toate subtask-urile de tip Task au status final
-# toate subtask-urile de tip QA Task cu status New
+      # 2. Tracker de tip Feature se va muta in status Ready for Testing cand sunt
+      # indeplinite urmatoarele conditii:
+      # -> feature-ul se afla in statusul In Progress
+      # -> toate subtask-urile de tip Task au status final
+      # -> toate subtask-urile de tip QA Task cu status New
       {
         :target_status => 'Ready for Testing',
         :tracker => ['Feature'],
@@ -59,7 +64,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           {
             :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
             :tracker =>  'Task',
-            :status => ["Completed", "Killed", "Party", "Fixed", "Delivered"]
+            :status => ['Completed', 'Killed', 'Party', 'Fixed', 'Delivered']
           },
           {
             :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
@@ -69,10 +74,11 @@ class AutostatusRuleDefinition < ActiveRecord::Base
 
         ]
       },
-# 3. Tracker de tip Feature se va muta in status In Testing cand sunt indeplinite urmatoarele conditii:
-# feature-ul se afla in statusul Ready For Testing
-# toate subtask-urile de tip Task au statusul Closed
-# cel putin un subtask de tip QA Task cu status In progress
+      # 3. Tracker de tip Feature se va muta in status In Testing cand sunt indeplinite
+      # urmatoarele conditii:
+      # -> feature-ul se afla in statusul Ready For Testing
+      # -> toate subtask-urile de tip Task au statusul Closed
+      # -> cel putin un subtask de tip QA Task cu status In progress
       {
         :target_status => 'In Testing',
         :tracker => ['Feature'],
@@ -81,7 +87,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           {
             :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
             :tracker =>  'Task',
-            :status => ["Completed"]
+            :status => ['Completed']
           },
           {
             :rule_type => AutostatusRuleCondition::RULE_TYPE_ONE,
@@ -92,38 +98,38 @@ class AutostatusRuleDefinition < ActiveRecord::Base
         ]
       },
     ]
-    rules.each { |rule|
+    rules.each do |rule|
       rule_definition = AutostatusRuleDefinition.new
       rule_definition.target_status_id = IssueStatus.find_by_name(rule[:target_status]).id
       rule_definition.save
 
-      rule[:tracker].each { |tracker|  
+      rule[:tracker].each do |tracker|
         feature = Tracker.find_by_name tracker
         autostatus_tracker = AutostatusTracker.new
         autostatus_tracker.autostatus_rule_definition = rule_definition
         autostatus_tracker.tracker_id = feature.id
         autostatus_tracker.save
-      }
-      rule[:current_status].each { |current_status|
+      end
+      rule[:current_status].each do |current_status|
         autostatus_current_status = AutostatusCurrentStatus.new
         autostatus_current_status.issue_status_id = IssueStatus.find_by_name(current_status).id
         autostatus_current_status.autostatus_rule_definition = rule_definition
         autostatus_current_status.save
-      }
-      rule[:conditions].each { |condition|  
+      end
+      rule[:conditions].each do |condition|
         autostatus_rule_condition = AutostatusRuleCondition.new
         autostatus_rule_condition.rule_type = condition[:rule_type]
         autostatus_rule_condition.tracker_id = Tracker.find_by_name(condition[:tracker]).id
         autostatus_rule_condition.autostatus_rule_definition = rule_definition
         autostatus_rule_condition.save
 
-        condition[:status].each { |status| 
+        condition[:status].each do |status|
           autostatus_rule_condition_status = AutostatusRuleConditionStatus.new
           autostatus_rule_condition_status.issue_status_id = IssueStatus.find_by_name(status).id
           autostatus_rule_condition_status.autostatus_rule_condition = autostatus_rule_condition
           autostatus_rule_condition_status.save
-        }
-      }
-    }
+        end
+      end
+    end
   end
 end

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -164,7 +164,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
             rule_comparator: :gt,
             rule_field_first: :due_date,
-            rule_field_second: :current_date
+            rule_field_second: :special_field_current_date
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -91,7 +91,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
             rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker:  'Task',
             rule_comparator: 'in',
-            rule_field_first: 'status.name',
+            rule_field_first: 'status_id',
             rule_values: ['In Progress']
           }
         ]
@@ -110,14 +110,14 @@ class AutostatusRuleDefinition < ActiveRecord::Base
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker:  'Task',
             rule_comparator: 'in',
-            rule_field_first: 'status.name',
+            rule_field_first: 'status_id',
             rule_values: ['Completed', 'Killed', 'Party', 'Fixed', 'Delivered']
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker:  'QA Task',
             rule_comparator: 'in',
-            rule_field_first: 'status.name',
+            rule_field_first: 'status_id',
             rule_values: ['New']
           }
         ]
@@ -126,7 +126,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
         # 3. Tracker de tip Feature se va muta in status In Testing cand sunt indeplinite
         # urmatoarele conditii:
         # -> feature-ul se afla in statusul Ready For Testing
-        # -> toate subtask-urile de tip Task au statusul Closed
+        # -> toate subtask-urile de tip Task au statusul Completed
         # -> cel putin un subtask de tip QA Task cu status In progress
         target_status: 'In Testing',
         tracker: ['Feature'],
@@ -136,14 +136,14 @@ class AutostatusRuleDefinition < ActiveRecord::Base
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker: 'Task',
             rule_comparator: 'in',
-            rule_field_first: 'status.name',
+            rule_field_first: 'status_id',
             rule_values: ['Completed']
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker: 'QA Task',
             rule_comparator: 'in',
-            rule_field_first: 'status.name',
+            rule_field_first: 'status_id',
             rule_values: ['In Progress']
           }
         ]

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -6,7 +6,6 @@ class AutostatusRuleDefinition < ActiveRecord::Base
   belongs_to :target_status, class_name: 'IssueStatus'
   attr_accessible :target_status, :priority
 
-
   def self.find_all_for(tracker_id, current_status_id)
     rules_by_current_status = AutostatusCurrentStatus.where(
       issue_status_id: current_status_id).pluck(:autostatus_rule_definition_id)
@@ -23,7 +22,6 @@ class AutostatusRuleDefinition < ActiveRecord::Base
     ).order('priority desc').order('id asc')
   end
 
-
   def valid(issue)
     conditions = autostatus_rule_condition
     issue_rule_status = true
@@ -38,66 +36,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
     AutostatusTracker.destroy_all
     AutostatusRuleCondition.destroy_all
     AutostatusCurrentStatus.destroy_all
-    rules = [
-      {
-        :target_status => 'In Progress',
-        :tracker => ['Feature'],
-        :current_status => ['Approved', 'Ready For Implementation'],
-        :conditions => [
-          {
-            :rule_type => AutostatusRuleCondition::RULE_TYPE_ONE,
-            :tracker =>  'Task',
-            :status => ['In Progress']
-          }
-        ]
-      },
-      # 2. Tracker de tip Feature se va muta in status Ready for Testing cand sunt
-      # indeplinite urmatoarele conditii:
-      # -> feature-ul se afla in statusul In Progress
-      # -> toate subtask-urile de tip Task au status final
-      # -> toate subtask-urile de tip QA Task cu status New
-      {
-        :target_status => 'Ready for Testing',
-        :tracker => ['Feature'],
-        :current_status => ['In Progress'],
-        :conditions => [
-          {
-            :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
-            :tracker =>  'Task',
-            :status => ['Completed', 'Killed', 'Party', 'Fixed', 'Delivered']
-          },
-          {
-            :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
-            :tracker =>  'QA Task',
-            :status => ['New']
-          }
-
-        ]
-      },
-      # 3. Tracker de tip Feature se va muta in status In Testing cand sunt indeplinite
-      # urmatoarele conditii:
-      # -> feature-ul se afla in statusul Ready For Testing
-      # -> toate subtask-urile de tip Task au statusul Closed
-      # -> cel putin un subtask de tip QA Task cu status In progress
-      {
-        :target_status => 'In Testing',
-        :tracker => ['Feature'],
-        :current_status => ['Ready for Testing'],
-        :conditions => [
-          {
-            :rule_type => AutostatusRuleCondition::RULE_TYPE_ALL,
-            :tracker =>  'Task',
-            :status => ['Completed']
-          },
-          {
-            :rule_type => AutostatusRuleCondition::RULE_TYPE_ONE,
-            :tracker =>  'QA Task',
-            :status => ['In Progress']
-          }
-
-        ]
-      },
-    ]
+    rules = self.populating_rules
     rules.each do |rule|
       rule_definition = AutostatusRuleDefinition.new
       rule_definition.target_status_id = IssueStatus.find_by_name(rule[:target_status]).id
@@ -131,5 +70,120 @@ class AutostatusRuleDefinition < ActiveRecord::Base
         end
       end
     end
+  end
+
+  def self.populating_rules
+    [
+      # 1. Tracker de tip Feature se va muta in status In Progress cand sunt indeplinite
+      # urmatoarele conditii
+      # -> feature-ul se afla in statusul Approved sau Ready For Implementation
+      # -> cel putin un subtask te tip Task cu statusul In Progress
+      {
+        target_status: 'In Progress',
+        tracker: ['Feature'],
+        current_status: ['Approved', 'Ready For Implementation'],
+        conditions: [
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_ONE,
+            rule_tracker:  'Task',
+            rule_comparator: :in,
+            rule_field_first: :status,
+            rule_field_first_values: ['In Progress']
+          }
+        ]
+      },
+      # 2. Tracker de tip Feature se va muta in status Ready for Testing cand sunt
+      # indeplinite urmatoarele conditii:
+      # -> feature-ul se afla in statusul In Progress
+      # -> toate subtask-urile de tip Task au status final
+      # -> toate subtask-urile de tip QA Task cu status New
+      {
+        target_status: 'Ready for Testing',
+        tracker: ['Feature'],
+        current_status: ['In Progress'],
+        conditions: [
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
+            rule_tracker:  'Task',
+            rule_comparator: :in,
+            rule_field_first: :status,
+            rule_field_first_values: ['Completed', 'Killed', 'Party', 'Fixed', 'Delivered']
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
+            rule_tracker:  'QA Task',
+            rule_comparator: :in,
+            rule_field_first: :status,
+            rule_field_first_values: ['New']
+          }
+        ]
+      },
+      # 3. Tracker de tip Feature se va muta in status In Testing cand sunt indeplinite
+      # urmatoarele conditii:
+      # -> feature-ul se afla in statusul Ready For Testing
+      # -> toate subtask-urile de tip Task au statusul Closed
+      # -> cel putin un subtask de tip QA Task cu status In progress
+      {
+        target_status: 'In Testing',
+        tracker: ['Feature'],
+        current_status: ['Ready for Testing'],
+        conditions: [
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
+            rule_tracker: 'Task',
+            rule_comparator: :in,
+            rule_field_first: :status,
+            rule_field_first_values: ['Completed']
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_ONE,
+            rule_tracker: 'QA Task',
+            rule_comparator: :in,
+            rule_field_first: :status,
+            rule_field_first_values: ['In Progress']
+          }
+        ]
+      },
+      # 4. Tracker de tip Feature se va muta in status Ready For Implementation cand
+      # sunt indeplinite urmatoarele conditii:
+      # -> due date > ziua curenta
+      # -> o persoana asignata
+      # -> o descriere
+      # -> asignat intr-un sprint
+      # -> o estimare
+      {
+        target_status: 'Ready For Implementation',
+        tracker: ['Feature'],
+        current_status: ['New'],
+        conditions: [
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_comparator: :gt,
+            rule_field_first: :due_date,
+            rule_field_second: :current_date
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_comparator: :not_null,
+            rule_field_first: :assignee
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_comparator: :not_empty,
+            rule_field_first: :description
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_comparator: :not_null,
+            rule_field_first: :sprint
+          },
+          {
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_comparator: :not_null,
+            rule_field_first: :estimation
+          }
+        ]
+      }
+    ]
   end
 end

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -90,8 +90,8 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker:  'Task',
-            rule_comparator: :in,
-            rule_field_first: :status,
+            rule_comparator: 'in',
+            rule_field_first: 'status.name',
             rule_values: ['In Progress']
           }
         ]
@@ -109,15 +109,15 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker:  'Task',
-            rule_comparator: :in,
-            rule_field_first: :status,
+            rule_comparator: 'in',
+            rule_field_first: 'status.name',
             rule_values: ['Completed', 'Killed', 'Party', 'Fixed', 'Delivered']
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker:  'QA Task',
-            rule_comparator: :in,
-            rule_field_first: :status,
+            rule_comparator: 'in',
+            rule_field_first: 'status.name',
             rule_values: ['New']
           }
         ]
@@ -135,15 +135,15 @@ class AutostatusRuleDefinition < ActiveRecord::Base
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_ALL,
             tracker: 'Task',
-            rule_comparator: :in,
-            rule_field_first: :status,
+            rule_comparator: 'in',
+            rule_field_first: 'status.name',
             rule_values: ['Completed']
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker: 'QA Task',
-            rule_comparator: :in,
-            rule_field_first: :status,
+            rule_comparator: 'in',
+            rule_field_first: 'status.name',
             rule_values: ['In Progress']
           }
         ]
@@ -162,29 +162,29 @@ class AutostatusRuleDefinition < ActiveRecord::Base
         conditions: [
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
-            rule_comparator: :gt,
-            rule_field_first: :due_date,
-            rule_field_second: :special_field_current_date
+            rule_comparator: 'gt',
+            rule_field_first: 'due_date',
+            rule_field_second: 'special_field_current_date'
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
-            rule_comparator: :not_null,
-            rule_field_first: :assignee
+            rule_comparator: 'not_null',
+            rule_field_first: 'assigned_to'
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
-            rule_comparator: :not_empty,
-            rule_field_first: :description
+            rule_comparator: 'not_empty',
+            rule_field_first: 'description'
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
-            rule_comparator: :not_null,
-            rule_field_first: :sprint
+            rule_comparator: 'not_null',
+            rule_field_first: 'fixed_version'
           },
           {
             rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
-            rule_comparator: :not_null,
-            rule_field_first: :estimation
+            rule_comparator: 'not_null',
+            rule_field_first: 'estimated_hours'
           }
         ]
       }

--- a/app/models/autostatus_rule_definition.rb
+++ b/app/models/autostatus_rule_definition.rb
@@ -88,7 +88,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
         current_status: ['Approved', 'Ready For Implementation'],
         conditions: [
           {
-            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker:  'Task',
             rule_comparator: :in,
             rule_field_first: :status,
@@ -140,7 +140,7 @@ class AutostatusRuleDefinition < ActiveRecord::Base
             rule_values: ['Completed']
           },
           {
-            rule_type: AutostatusRuleCondition::RULE_TYPE_SELF,
+            rule_type: AutostatusRuleCondition::RULE_TYPE_SINGLE,
             tracker: 'QA Task',
             rule_comparator: :in,
             rule_field_first: :status,

--- a/db/migrate/001_create_autostatus_trackers.rb
+++ b/db/migrate/001_create_autostatus_trackers.rb
@@ -1,17 +1,10 @@
 class CreateAutostatusTrackers < ActiveRecord::Migration
   def change
     create_table :autostatus_trackers do |t|
-
       t.references :tracker
-
       t.references :autostatus_rule_definition
-
-
     end
-
     add_index :autostatus_trackers, :tracker_id
-
     add_index :autostatus_trackers, :autostatus_rule_definition_id, :name => 'autostatus_tracker_rule_definition'
-
   end
 end

--- a/db/migrate/002_create_autostatus_current_statuses.rb
+++ b/db/migrate/002_create_autostatus_current_statuses.rb
@@ -6,6 +6,5 @@ class CreateAutostatusCurrentStatuses < ActiveRecord::Migration
     end
     add_index :autostatus_current_statuses, :issue_status_id
     add_index :autostatus_current_statuses, :autostatus_rule_definition_id,  :name => 'autostatus_status_rule_definition'
-
   end
 end

--- a/db/migrate/005_create_autostatus_rule_condition_statuses.rb
+++ b/db/migrate/005_create_autostatus_rule_condition_statuses.rb
@@ -3,12 +3,8 @@ class CreateAutostatusRuleConditionStatuses < ActiveRecord::Migration
     create_table :autostatus_rule_condition_statuses do |t|
       t.references :autostatus_rule_condition
       t.references :issue_status
-
     end
-
     add_index :autostatus_rule_condition_statuses, :autostatus_rule_condition_id, :name => 'autostatus_rule_condition_statuses_condition'
     add_index :autostatus_rule_condition_statuses, :issue_status_id, :name => 'autostatus_rule_condition_statuses_status'
-
-
   end
 end

--- a/db/migrate/007_add_columns_to_autostatus_rule_conditions.rb
+++ b/db/migrate/007_add_columns_to_autostatus_rule_conditions.rb
@@ -1,0 +1,7 @@
+class AddColumnsToAutostatusRuleConditions < ActiveRecord::Migration
+  def change
+    add_column :autostatus_rule_conditions, :rule_comparator, :string
+    add_column :autostatus_rule_conditions, :rule_field_first, :string
+    add_column :autostatus_rule_conditions, :rule_field_second, :string
+  end
+end

--- a/lib/patches/autostatus_issue_patch.rb
+++ b/lib/patches/autostatus_issue_patch.rb
@@ -13,16 +13,13 @@ module AutostatusIssuePatch
   module InstanceMethods
     def trigger_autostatus_rules
       apply_autostatus_rules
-      # unless parent.nil?
-      #   parent.apply_autostatus_rules
-      # end
+      parent.apply_autostatus_rules if parent
     end
 
     def apply_autostatus_rules
-      #find if we have rules
       rules = AutostatusRuleDefinition.find_all_for(tracker_id, status_id)
       rules.each do |rule|
-        next unless rule.valid self
+        next unless rule.valid? self
         old_status = self.status.name
         self.status_id = rule.target_status_id
         next unless save

--- a/lib/patches/autostatus_issue_patch.rb
+++ b/lib/patches/autostatus_issue_patch.rb
@@ -3,7 +3,7 @@ module AutostatusIssuePatch
     base.extend(ClassMethods)
     base.send(:include, InstanceMethods)
     base.class_eval do
-      after_save :trigger_autostatus_rules
+      around_save :trigger_autostatus_rules
     end
   end
 
@@ -12,6 +12,9 @@ module AutostatusIssuePatch
 
   module InstanceMethods
     def trigger_autostatus_rules
+      manually_changed = status_id_changed?
+      yield
+      return if manually_changed
       apply_autostatus_rules
       parent.apply_autostatus_rules if parent
     end

--- a/lib/patches/autostatus_issue_patch.rb
+++ b/lib/patches/autostatus_issue_patch.rb
@@ -20,7 +20,7 @@ module AutostatusIssuePatch
 
     def apply_autostatus_rules
       #find if we have rules
-      rules = AutostatusRuleDefinition.find_all_by_tracker_and_current_status_id(tracker_id, status_id)
+      rules = AutostatusRuleDefinition.find_all_for(tracker_id, status_id)
       rules.each do |rule|
         next unless rule.valid self
         old_status = self.status.name

--- a/lib/patches/autostatus_issue_patch.rb
+++ b/lib/patches/autostatus_issue_patch.rb
@@ -18,18 +18,22 @@ module AutostatusIssuePatch
 
     def apply_autostatus_rules
       rules = AutostatusRuleDefinition.find_all_for(tracker_id, status_id)
+      old_status = nil
+      new_status = nil
       rules.each do |rule|
         next unless rule.valid self
-        old_status = self.status.name
+        old_status ||= self.status.name
         self.status_id = rule.target_status_id
-        next unless save
-        journal = init_journal(User.current, '')
-        journal.details << JournalDetail.new(property: 'attr',
-                                             prop_key: 'status',
-                                             old_value: old_status,
-                                             value: self.status.name)
-        journal.save!
+        new_status = self.status.name
+        save!
       end
+      return unless old_status
+      journal = init_journal(User.current, '')
+      journal.details << JournalDetail.new(property: 'attr',
+                                           prop_key: 'status',
+                                           old_value: old_status,
+                                           value: self.status.name)
+      journal.save!
     end
   end
 end

--- a/lib/patches/autostatus_issue_patch.rb
+++ b/lib/patches/autostatus_issue_patch.rb
@@ -19,7 +19,7 @@ module AutostatusIssuePatch
     def apply_autostatus_rules
       rules = AutostatusRuleDefinition.find_all_for(tracker_id, status_id)
       rules.each do |rule|
-        next unless rule.valid? self
+        next unless rule.valid self
         old_status = self.status.name
         self.status_id = rule.target_status_id
         next unless save


### PR DESCRIPTION
Issues can now be automated based on rules that apply to themselves.
This adds support for almost arbitrary rules, non self rules still take into account only the status.
